### PR TITLE
Update build targets to API 34 and modernize AndroidManifest permissions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,9 +14,8 @@ android {
     dexOptions {
         javaMaxHeapSize "4g"
     }
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
-    dataBinding {
+    compileSdkVersion 34
+        dataBinding {
         enabled = true
     }
     buildFeatures {
@@ -25,8 +24,8 @@ android {
     }
     defaultConfig {
         applicationId "cn.darkal.networkdiagnosis"
-        minSdkVersion 14
-        targetSdkVersion 27
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 31
         versionName "3.2.31"
         // Enabling multidex support.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,21 +2,25 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="cn.darkal.networkdiagnosis">
 
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.MOUNT_UNMOUNT_FILESYSTEMS" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.FLASHLIGHT" />
-    <uses-permission android:name="android.permission.READ_LOGS" />
+    
+    
 
     <application
+        android:requestLegacyExternalStorage="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:name=".SysApplication"
         android:allowBackup="true"
@@ -44,6 +48,7 @@
 
         <activity
             android:name=".Activity.MainActivity"
+            android:exported="true"
             android:configChanges="orientation|keyboardHidden"
             android:label="@string/app_name"
             android:launchMode="singleTask"
@@ -75,10 +80,12 @@
         </activity>
         <activity
             android:name="com.google.zxing.QrCodeScanActivity"
+            android:exported="false"
             android:screenOrientation="portrait" />
 
         <service
             android:name=".MyVpnService"
+            android:exported="false"
             android:permission="android.permission.BIND_VPN_SERVICE">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
@@ -87,11 +94,13 @@
 
         <activity
             android:name=".Activity.SettingsActivity"
+            android:exported="false"
             android:label="@string/title_activity_settings" />
 
         <!-- 引用xml策略声明 -->
         <receiver
             android:name=".Receiver.MyAdminReceiver"
+            android:exported="false"
             android:description="@string/app_name"
             android:label="@string/app_name"
             android:permission="android.permission.BIND_DEVICE_ADMIN">
@@ -105,13 +114,17 @@
         </receiver>
 
         <activity
-            android:name=".Activity.HarDetailActivity" />
+            android:name=".Activity.HarDetailActivity"
+            android:exported="false" />
         <activity
-            android:name=".Activity.JsonPreviewActivity" />
+            android:name=".Activity.JsonPreviewActivity"
+            android:exported="false" />
         <activity
             android:name="com.tencent.bugly.beta.ui.BetaActivity"
+            android:exported="false"
             android:theme="@android:style/Theme.Translucent" />
-        <activity android:name=".Activity.ChangeFilterActivity"></activity>
+        <activity android:name=".Activity.ChangeFilterActivity"
+            android:exported="false"></activity>
     </application>
 
 </manifest>


### PR DESCRIPTION
### Motivation
- Bring the app build configuration up to current Android platform levels so modern devices and Play policies are supported by setting `compileSdkVersion` and `targetSdkVersion` to 34. 
- Raise the `minSdkVersion` to a reasonable modern baseline to reduce legacy compatibility work and reliance on removed platform APIs by setting `minSdkVersion` to 21. 
- Align manifest permissions and component declarations with Android 12/13+ requirements to avoid install/runtime failures and to follow the scoped storage and permission model. 

### Description
- Updated `app/build.gradle` to set `compileSdkVersion 34`, removed the explicit `buildToolsVersion` entry, set `targetSdkVersion 34`, and bumped `minSdkVersion` to `21`. 
- Modified `app/src/main/AndroidManifest.xml` to constrain legacy permissions with `android:maxSdkVersion` for `READ_PHONE_STATE` and `READ_EXTERNAL_STORAGE`, added Android 13 media permissions `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO`, and `READ_MEDIA_AUDIO`, and removed deprecated/privileged permissions such as `MOUNT_UNMOUNT_FILESYSTEMS`, `FLASHLIGHT`, and `READ_LOGS`. 
- Added `android:requestLegacyExternalStorage=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e4d908f0832f9d3db8ed0e7ec692)